### PR TITLE
Now builds against non-snapshot version of OpenAM 14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,18 +18,14 @@
     <packaging>jar</packaging>
 
     <properties>
-        <openam.version>14.0.0-SNAPSHOT</openam.version>
+        <openam.version>14.0.0</openam.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
      <repositories>
         <repository>
-            <id>forgerock-internal-releases</id>
-            <url>https://maven.forgerock.org/repo/internal-releases</url>
-        </repository>
-        <repository>
-            <id>forgerock-internal-snapshots</id>
-            <url>https://maven.forgerock.org/repo/internal-snapshots</url>
+            <id>forgerock-private-releases</id>
+            <url>https://maven.forgerock.org/repo/private-releases</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Fixes #1 

Now builds against OpenAM 14.0.0. 

n.b. This project pulls artefacts from the ForgeRock private releases maven repository. Access to this repository requires an active subscription.